### PR TITLE
Pull Bouncy Castle via Gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ standalone CloverDX Server with good defaults, in a recommended environment.
 * Checkout or download this repository (Checkout via ``git clone https://github.com/cloverdx/cloverdx-server-docker.git``)
 * Download `clover.war` for Tomcat from <https://www.cloverdx.com>
 * Put `clover.war` into `cloverdx-server-docker` directory (current working directory containing the `Dockerfile`).
-* Optional: run `gradlew` to download additional dependencies, e.g. JDBC drivers.
+* Optional: run `gradlew` to download additional dependencies, e.g. JDBC drivers and stronger cryptography.
 * Build the Docker image:
 
     ```
@@ -35,7 +35,7 @@ standalone CloverDX Server with good defaults, in a recommended environment.
     * ``--mount type=bind,source=/data/your-host-clover-home-dir,target=/var/clover`` - mount the ``/data/your-host-clover-home-dir`` directory from the host as a data volume into ``/var/clover`` path inside the container, this will contain the persistent data, configuration, etc.
     * ``cloverdx-server:latest`` - name of the image to run as a container
 
-**Success**. CloverDX Server is now available at <http://localhost:8080/clover>. The Server is running with default settings, and **should be configured further** to get it into production quality (i.e. it should use external database).
+**Success**. CloverDX Server is now available at <http://localhost:8080/clover>. The Server is running with default settings, and **should be configured further** to get it into production quality (i.e. it should use an external database and set a cryptography master password).
 
 ---
 
@@ -294,8 +294,9 @@ Cryptography in CloverDX is used primarily for [Secure Parameters](https://doc.c
 
 ### Install Bouncy Castle
 
-* download Bouncy Castle JAR ( e.g. ``bcprov-jdk15on-162.jar`` from [here](https://www.bouncycastle.org/latest_releases.html))
-* get the JAR on server classpath - place it in ``tomcat-lib/`` in the mounted volume
+Run `./gradlew addStrongCrypto` to pull the latest version of BouncyCastle from Maven Central into `tomcat-lib/` in the mounted volume.
+
+To control the version of Bouncy Castle deployed, change `latest.release` in `gradle.build` to the version available in [Maven Central](https://search.maven.org/artifact/org.bouncycastle/bcprov-jdk15on) on which you want to pin. Be sure to check Bouncy Castle regularly for security updates.
 
 ### Secure Configuration Properties
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ repositories {
 defaultTasks 'build'
 
 configurations {
+	dbDriver { transitive = false }
 	tomcatLib { transitive = false }
 	cloverLib { transitive = false }
 	prometheus { transitive = false }
@@ -13,18 +14,25 @@ configurations {
 
 dependencies {
 	cloverLib "javax.jms:javax.jms-api:2.0.1"
-	
-	tomcatLib "com.microsoft.sqlserver:sqljdbc4:4.0"
-	tomcatLib "mysql:mysql-connector-java:5.1.47"
-	tomcatLib "com.oracle:ojdbc6:11.2.0.3"
-	tomcatLib "org.postgresql:postgresql:42.2.12"
+
+	dbDriver "com.microsoft.sqlserver:sqljdbc4:4.0"
+	dbDriver "mysql:mysql-connector-java:5.1.47"
+	dbDriver "com.oracle:ojdbc6:11.2.0.3"
+	dbDriver "org.postgresql:postgresql:42.2.12"
+
+	tomcatLib "org.bouncycastle:bcprov-jdk15on:latest.release"
 
 	prometheus "io.prometheus.jmx:jmx_prometheus_javaagent:0.12.0"
 }
 
+task copyDbDriver(type: Copy) {
+	from configurations.dbDriver
+	into "public/var/dbdrivers"
+}
+
 task copyTomcatLib(type: Copy) {
 	from configurations.tomcatLib
-	into "public/var/dbdrivers"
+	into "public/var/tomcat-lib"
 }
 
 task copyCloverLib(type: Copy) {
@@ -43,5 +51,8 @@ tasks.withType(Copy) {
 	eachFile { logger.lifecycle("* {}", it.file.name) }
 }
 
-task build(dependsOn: [copyTomcatLib, copyCloverLib]) {
+task build(dependsOn: [copyDbDriver, copyTomcatLib, copyCloverLib]) {
 }
+
+task addStrongCrypto(dependsOn: [copyTomcatLib])
+

--- a/public/tomcat/defaults/clover.properties
+++ b/public/tomcat/defaults/clover.properties
@@ -45,3 +45,11 @@
 #jdbc.username=user
 #jdbc.password=pass
 #jdbc.dialect=org.hibernate.dialect.PostgreSQLDialect
+
+## Example configuration for BouncyCastle encryption provider
+## Secure Configuration
+#security.config_properties.encryptor.providerClassName=org.bouncycastle.jce.provider.BouncyCastleProvider
+#security.config_properties.encryptor.algorithm=PBEWITHSHA256AND256BITAES-CBC-BC
+##Secure Parameters
+#security.job_parameters.encryptor.providerClassName=org.bouncycastle.jce.provider.BouncyCastleProvider
+#security.job_parameters.encryptor.algorithm=PBEWITHSHA256AND256BITAES-CBC-BC


### PR DESCRIPTION
It is easier to download Bouncy Castle from Maven Central via the project's Gradle build, rather than making the system configurator download it manually from the project's website. This also makes the build fully automatable for CI/CD.